### PR TITLE
indentation and invalid naming

### DIFF
--- a/kubernetes/configmaps/auto-configmap.yml
+++ b/kubernetes/configmaps/auto-configmap.yml
@@ -1,10 +1,10 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: auto_conf
+  name: auto-conf
   namespace: netsil
 data:
- apache.yaml: |
+  apache.yaml: |
         docker_images:
           - httpd
 


### PR DESCRIPTION
The `_` in the name is invalid, and the config map cannot be created with the current name
```
$ kubectl create -f auto-configmap.yaml --validate
The ConfigMap "auto_conf" is invalid: metadata.name: Invalid value: "auto_conf": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

Incorrect indentation causes a  "did not find expected key" error to be thrown
```
$ kubectl create -f auto-configmap.yaml
error: error converting YAML to JSON: yaml: line 14: did not find expected key
```