### PR TITLE
Feature/k8s rbac collector

### DIFF
--- a/kubernetes/collector-rbac.yaml
+++ b/kubernetes/collector-rbac.yaml
@@ -1,0 +1,67 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  namespace: netsil
+  name: collector
+  labels:
+    app: netsil
+    component: collector
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: netsil
+        component: collector
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: netsil
+      containers:
+      - name: collector
+        image: netsil/collectors:latest
+        command: ["/bin/bash","-c","while true ; do NETSIL_SP_HOST=$NETSIL_SERVICE_HOST /opt/netsil/collectors/start.sh ; echo Exiting, possibly to upgrade ; sleep 5 ; done"]
+        securityContext:
+          capabilities:
+            add:
+            - NET_RAW
+            - NET_ADMIN
+        env:
+        #- name: NETSIL_SERVICE_HOST
+        #  value: "<AOC address here>"
+        #- name: NETSIL_ORGANIZATION_ID
+        #  value: "<Netsil Organization ID>"
+        - name: DEPLOY_ENV
+          value: "docker"
+        - name: KUBERNETES
+          value: "yes"
+        - name: SD_BACKEND
+          value: "docker"
+        - name: KUBERNETES_KUBELET_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        volumeMounts:
+        - name: cgroup
+          mountPath: /host/sys/fs/cgroup/
+          readOnly: true
+        - name: proc
+          mountPath: /host/proc/
+          readOnly: true
+        - name: docker-sock
+          mountPath: /var/run/docker.sock
+          readOnly: true
+      volumes:
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup/
+      - name: proc
+        hostPath:
+          path: /proc/
+      - name: docker-sock
+        hostPath:
+          path: /var/run/docker.sock

--- a/kubernetes/configmaps/auto-configmap.yml
+++ b/kubernetes/configmaps/auto-configmap.yml
@@ -1,10 +1,10 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: auto_conf
+  name: auto-conf
   namespace: netsil
 data:
- apache.yaml: |
+  apache.yaml: |
         docker_images:
           - httpd
 

--- a/kubernetes/configmaps/collector.yaml
+++ b/kubernetes/configmaps/collector.yaml
@@ -50,7 +50,7 @@ spec:
           readOnly: true
         - name: configmap-volume
           mountPath: /etc/netsil-dd-agent/conf.d/
-        - name: configmap-auto_conf
+        - name: configmap-auto-conf
           mountPath: /etc/netsil-dd-agent/auto_conf/
       volumes:
       - name: cgroup
@@ -65,6 +65,6 @@ spec:
       - name: configmap-volume
         configMap:
           name: integrations
-      - name: configmap-auto_conf
+      - name: configmap-auto-conf
         configMap:
-          name: auto_conf
+          name: auto-conf

--- a/kubernetes/rbac-setup.yaml
+++ b/kubernetes/rbac-setup.yaml
@@ -1,0 +1,36 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: netsil
+rules:
+  - nonResourceURLs:
+      - "/version"
+      - "/healthz"
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources:
+      - "nodes"
+      - "namespaces"
+      - "events"
+      - "services"
+    verbs: ["get", "list"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: netsil
+automountServiceAccountToken: true
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: netsil
+subjects:
+  - kind: ServiceAccount
+    name: netsil
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: netsil
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
I encountered an issue with deploying the collector agent in my kubernetes cluster due to the fact I have RBAC enabled, and the collector agent was not authorised to view the kublet resources.

The rbac-setup.yaml creates the service accounts and role accounts for the collector agent to be able to work. The collector-rbac.yaml is the same as the example provided, but including the newly created service account. (We could also include this into one manfiest?)

This is working for me, and I thought it would help any body else who may have a similar deployment to mine